### PR TITLE
fix(library): correct typo in date field for 'the-5.mdx'

### DIFF
--- a/content/library/the-5.mdx
+++ b/content/library/the-5.mdx
@@ -3,7 +3,7 @@ title: "The 5"
 author: "Tomasz Karwatka"
 published: true
 status: "read"
-date: "20205-12-24"
+date: "2025-12-24"
 bookType: "paper"
 tag: "Business"
 cover: "/books/the-5.jpeg"


### PR DESCRIPTION
Since this is a minor fix, I decided not to report it as an issue.